### PR TITLE
Gate 'Paiement direct Fournisseur' button behind the payment permission

### DIFF
--- a/clientpayfourncheck.php
+++ b/clientpayfourncheck.php
@@ -59,6 +59,9 @@ if (!$res) {
 // Load translation files required by the page
 $langs->loadLangs(array("clientpayfourn@clientpayfourn"));
 
+// Same permission as the core "Saisir règlement" (enter payment) button on the customer invoice card
+$usercanissuepayment = $user->hasRight('facture', 'paiement');
+
 $action = GETPOST('action', 'aZ09');
 $clientid = GETPOST('clientid', 'int');
 $fournid = GETPOST('fournid', 'int');
@@ -137,4 +140,9 @@ if ($n == 0) {
 print '</table>';
 
 print '</div>';
+
+// Expose the payment permission to the JS so the direct-payment button is only rendered
+// for users allowed to enter a payment (same right as the core "Saisir règlement" button).
+print '<span id="clientpayfourn-canpay" data-canpay="'.($usercanissuepayment ? 1 : 0).'"></span>';
+
 $db->close();

--- a/clientpayfournindex.php
+++ b/clientpayfournindex.php
@@ -68,6 +68,11 @@ global $db, $user, $conf, $langs;
 // Load translation files required by the page
 $langs->loadLangs(array("clientpayfourn@clientpayfourn"));
 
+// Security check - same permission as the core "Saisir règlement" (enter payment) button
+if (!$user->hasRight('facture', 'paiement')) {
+	accessforbidden();
+}
+
 $action = GETPOST('action', 'aZ09');
 $facture_id = GETPOSTINT('id');
 $supplier_invoice_id = GETPOSTINT('supplier_invoice_id');

--- a/js/clientpayfourn.js.php
+++ b/js/clientpayfourn.js.php
@@ -98,24 +98,7 @@ $paydirectfourn = $langs->trans("ClientPayFournButton");
 /* Javascript library of module ClientPayFourn */
 
 $(document).ready(function () {
-	// if we aren't on the Tier page, don't do anything
-	if (window.location.href.indexOf("/compta/facture/card.php") === -1) {
-		return;
-	}
-	const id = window.location.href.split("id=")[1].split("&")[0];
-	// if there are a button with "Valider" inside
-	const disabled = $(".badge.badge-status1.badge-status").length <= 0;
-
-	if (disabled) return;
-
-	const last = $(".tabsAction").first();
-
-	last.prepend(
-		"<a href='/custom/clientpayfourn/clientpayfournindex.php?id=" + id + "' class='butAction'><?= $paydirectfourn ?></a>"
-	);
-});
-
-$(document).ready(function () {
+	// if we aren't on the customer invoice card, don't do anything
 	if (window.location.href.indexOf("/compta/facture/card.php") === -1) {
 		return;
 	}
@@ -123,6 +106,17 @@ $(document).ready(function () {
 
 	$.get("/custom/clientpayfourn/clientpayfourncheck.php?clientid=" + id, function (data) {
 		$(".fichehalfright").last().append(data);
+
+		// Only show the direct payment button to users allowed to enter a payment
+		// (same right as the core "Saisir règlement" button) and when the invoice is validated.
+		const canpay = $("#clientpayfourn-canpay").data("canpay") == 1;
+		const validated = $(".badge.badge-status1.badge-status").length > 0;
+
+		if (canpay && validated) {
+			$(".tabsAction").first().prepend(
+				"<a href='/custom/clientpayfourn/clientpayfournindex.php?id=" + id + "' class='butAction'><?= $paydirectfourn ?></a>"
+			);
+		}
 	});
 });
 


### PR DESCRIPTION
## What

Restrict the 'Paiement direct Fournisseur' button (and its target page) to users who hold the same right as the core 'Saisir reglement' button, i.e. `facture/paiement`.

## Why

Today the button is prepended to the customer invoice card for every user who can view the page, and `clientpayfournindex.php` (the direct-payment page) has no access control at all, so anyone could open it by URL.

## How

- `js/clientpayfourn.js.php`: the button injection is merged into the per-user AJAX callback. The JS file runs with `NOLOGIN` and is publicly cached, so it cannot evaluate user rights itself. The button is now added only when the user is allowed and the invoice is validated. Fail-closed: no flag, no button.
- `clientpayfourncheck.php`: resolves `$user->hasRight('facture', 'paiement')` per user and exposes it to the JS via a `data-canpay` flag.
- `clientpayfournindex.php`: adds a server-side `accessforbidden()` guard on the same right, so hiding the button is backed by a real access check.

## Notes

- The supplier invoice card has no such button in the code, so nothing to gate there.
- Not run locally: no PHP runtime or Docker available in this environment.